### PR TITLE
Fix subsetting and start testing

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pfields
 Title: An R Package to Analyse Gridded Field Data
-Version: 0.0.0.9000
+Version: 0.1.1.9000
 Author:
   Thomas Muench [aut, cre],
   Thomas Laepple [aut]

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,3 +17,5 @@ LazyData: true
 RoxygenNote: 6.1.1
 Imports: 
     geosphere
+Suggests:
+    testthat

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+test:
+	- Rscript -e "devtools::test()"

--- a/R/indexing-methods.R
+++ b/R/indexing-methods.R
@@ -120,6 +120,12 @@
     if (nobs != length(res) | n2 == 1) {
 
       # subset not pField-compatible or single site; return pTs object
+
+      if (nrow(x) == 1 & n2 > 1) {
+        # preserve matrix for single time step at multiple sites
+        dim(res) <- c(1, n2)
+      }
+
       res <- pTs(res, stats::time(x), lat, lon,
                  atb$name, atb$history, date = FALSE)
 
@@ -239,6 +245,11 @@
     #[, b] given; give back time series b
 
     hist <- sprintf("Subset [, %s]", deparse(substitute(p2)))
+
+    if (nrow(x) == 1 & length(p2) > 1) {
+      # preserve matrix for single time step at multiple columns
+      dim(res) <- c(1, length(res))
+    }
 
     res <- pTs(res, stats::time(x),
                lat = atb$lat[p2.l], lon = atb$lon[p2.l],

--- a/R/indexing-methods.R
+++ b/R/indexing-methods.R
@@ -61,6 +61,12 @@
       if (nobs != length(res) | n2 == 1) {
 
         # subset not pField-compatible or single site; return pTs object
+
+        if (length(p1) == 1 & length(p2) > 1) {
+          # preserve matrix for single time step at multiple sites
+          dim(res) <- c(1, length(p2))
+        }
+
         res <- pTs(res, stats::time(x)[p1], lat, lon,
                    atb$name, atb$history, date = FALSE)
 
@@ -172,6 +178,11 @@
 
       # [a, b] given; give back time series b at times a
 
+      if (length(p1) == 1 & length(p2) > 1) {
+        # preserve matrix for single time step at multiple columns
+        dim(res) <- c(1, length(res))
+      }
+
       hist <- sprintf("Subset [%s, %s]",
                       deparse(substitute(p1)),
                       deparse(substitute(p2)))
@@ -199,6 +210,11 @@
         # [a, ] requested; give back time series at times a
 
         hist <- sprintf("Subset [%s, ]", deparse(substitute(p1)))
+
+        if (length(p1) == 1) {
+          # preserve matrix for single time step at multiple columns
+          dim(res) <- c(1, length(res))
+        }
 
         res <- pTs(res, stats::time(x)[p1], lat = atb$lat, lon = atb$lon,
                    name = atb$name, atb$history, date = FALSE)

--- a/R/indexing-methods.R
+++ b/R/indexing-methods.R
@@ -178,7 +178,7 @@
     p2.n <- 1
 
     if (length(atb$lat) > 1) p2.l <- p2
-    if (length(atb$name) > 1) p2.l <- p2
+    if (length(atb$name) > 1) p2.n <- p2
   }
 
   if (is.p1) {

--- a/R/indexing-methods.R
+++ b/R/indexing-methods.R
@@ -62,9 +62,9 @@
 
         # subset not pField-compatible or single site; return pTs object
 
-        if (length(p1) == 1 & length(p2) > 1) {
+        if (n1 == 1 & n2 > 1) {
           # preserve matrix for single time step at multiple sites
-          dim(res) <- c(1, length(p2))
+          dim(res) <- c(1, n2)
         }
 
         res <- pTs(res, stats::time(x)[p1], lat, lon,
@@ -169,6 +169,9 @@
   res <- NextMethod("[")
   atb <- attributes(x)
 
+  if (is.p1) n1 <- length(p1)
+  if (is.p2) n2 <- length(p2)
+
   if (is.p2) {
 
     p2.l <- 1
@@ -184,7 +187,7 @@
 
       # [a, b] given; give back time series b at times a
 
-      if (length(p1) == 1 & length(p2) > 1) {
+      if (n1 == 1 & n2 > 1) {
         # preserve matrix for single time step at multiple columns
         dim(res) <- c(1, length(res))
       }
@@ -211,13 +214,13 @@
         # check if [a] oder [a, ] is requested from multivariate pTs
         
       } else if (is.array(res) |
-                 (length(res) == ncol(x) & length(p1) == 1)) {
+                 (length(res) == ncol(x) & n1 == 1)) {
 
         # [a, ] requested; give back time series at times a
 
         hist <- sprintf("Subset [%s, ]", deparse(substitute(p1)))
 
-        if (length(p1) == 1) {
+        if (n1 == 1) {
           # preserve matrix for single time step at multiple columns
           dim(res) <- c(1, length(res))
         }
@@ -246,7 +249,7 @@
 
     hist <- sprintf("Subset [, %s]", deparse(substitute(p2)))
 
-    if (nrow(x) == 1 & length(p2) > 1) {
+    if (nrow(x) == 1 & n2 > 1) {
       # preserve matrix for single time step at multiple columns
       dim(res) <- c(1, length(res))
     }

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,4 @@
+library(testthat)
+library(pfields)
+
+test_check("pfields")

--- a/tests/testthat/test-indexing.R
+++ b/tests/testthat/test-indexing.R
@@ -1,7 +1,7 @@
 
 context("test-indexing")
 
-test_that("pField indexing works correctly", {
+test_that("pField indexing works correctly.", {
 
   # Create a pField
   lat <- c(-75, -80)
@@ -57,6 +57,108 @@ test_that("pField indexing works correctly", {
   expect_true(is.pField(subset))
 
   expect_error(subset <- pfield[1 : 3, 1 : 5], NA)
+  expect_true(is.pTs(subset))
+
+})
+
+test_that("pTs indexing works correctly for single-site pTs.", {
+
+  # Create a pTs object with 10 data sets from the same site
+  dat <- matrix(rnorm(10 * 100), nrow = 100, ncol = 10)
+  pts <- pTs(dat, lat = -75, lon = 0,
+             name = "10 proxy time series.")
+
+  # Test single indexing
+
+  expect_error(subset <- pts[1, ], NA)
+  expect_true(is.pTs(subset))
+  expect_equal(dim(subset), c(1, 10))
+
+  expect_error(subset <- pts[, 1], NA)
+  expect_true(is.pTs(subset))
+  expect_equal(dim(subset), NULL)
+
+  expect_warning(subset <- pts[10])
+
+  expect_error(subset <- pts[1, 1], NA)
+  expect_true(is.pTs(subset))
+  expect_equal(dim(subset), NULL)
+
+  # Test 1D vector indexing
+
+  expect_warning(subset <- pts[1 : 10])
+
+  expect_error(subset <- pts[1 : 3, ], NA)
+  expect_true(is.pTs(subset))
+
+  expect_error(subset <- pts[, 1 : 3], NA)
+  expect_true(is.pTs(subset))
+
+  # Test indexing by one vector and one integer
+
+  expect_error(subset <- pts[1, 1 : 3], NA)
+  expect_true(is.pTs(subset))
+  expect_equal(dim(subset), c(1, 3))
+
+  expect_error(subset <- pts[1 : 3, 1], NA)
+  expect_true(is.pTs(subset))
+  expect_equal(dim(subset), NULL)
+
+  # Test 2D vector indexing
+
+  expect_error(subset <- pts[1 : 3, 1 : 3], NA)
+  expect_true(is.pTs(subset))
+
+})
+
+test_that("pTs indexing works correctly for multi-site pTs.", {
+
+  # Create a pTs object with 10 data sets from the same site
+  dat <- matrix(rnorm(10 * 100), nrow = 100, ncol = 10)
+  lat <- seq(-75, -85, length.out = 10)
+  lon <- seq(0, 90, length.out = 10)
+  pts <- pTs(dat, lat = lat, lon = lon,
+             name = "Proxy time series from 10 sites.")
+
+  # Test single indexing
+
+  expect_error(subset <- pts[1, ], NA)
+  expect_true(is.pTs(subset))
+  expect_equal(dim(subset), c(1, 10))
+
+  expect_error(subset <- pts[, 1], NA)
+  expect_true(is.pTs(subset))
+  expect_equal(dim(subset), NULL)
+
+  expect_warning(subset <- pts[10])
+
+  expect_error(subset <- pts[1, 1], NA)
+  expect_true(is.pTs(subset))
+  expect_equal(dim(subset), NULL)
+
+  # Test 1D vector indexing
+
+  expect_warning(subset <- pts[1 : 10])
+
+  expect_error(subset <- pts[1 : 3, ], NA)
+  expect_true(is.pTs(subset))
+
+  expect_error(subset <- pts[, 1 : 3], NA)
+  expect_true(is.pTs(subset))
+
+  # Test indexing by one vector and one integer
+
+  expect_error(subset <- pts[1, 1 : 3], NA)
+  expect_true(is.pTs(subset))
+  expect_equal(dim(subset), c(1, 3))
+
+  expect_error(subset <- pts[1 : 3, 1], NA)
+  expect_true(is.pTs(subset))
+  expect_equal(dim(subset), NULL)
+
+  # Test 2D vector indexing
+
+  expect_error(subset <- pts[1 : 3, 1 : 3], NA)
   expect_true(is.pTs(subset))
 
 })

--- a/tests/testthat/test-indexing.R
+++ b/tests/testthat/test-indexing.R
@@ -16,9 +16,11 @@ test_that("pField indexing works correctly.", {
 
   expect_error(subset <- pfield[1, ], NA)
   expect_true(is.pField(subset))
+  expect_equal(dim(subset), c(1, 6))
 
   expect_error(subset <- pfield[, 1], NA)
   expect_true(is.pTs(subset))
+  expect_equal(dim(subset), NULL)
 
   expect_warning(subset <- pfield[10])
   expect_equal(c(subset), 10)
@@ -44,12 +46,15 @@ test_that("pField indexing works correctly.", {
 
   expect_error(subset <- pfield[1, 1 : 3], NA)
   expect_true(is.pField(subset))
+  expect_equal(dim(subset), c(1, 3))
 
   expect_error(subset <- pfield[1, 1 : 4], NA)
   expect_true(is.pTs(subset))
+  expect_equal(dim(subset), c(1, 4))
 
   expect_error(subset <- pfield[1 : 3, 1], NA)
   expect_true(is.pTs(subset))
+  expect_equal(dim(subset), NULL)
 
   # Test 2D vector indexing
 

--- a/tests/testthat/test-indexing.R
+++ b/tests/testthat/test-indexing.R
@@ -18,6 +18,10 @@ test_that("pField indexing works correctly.", {
   expect_true(is.pField(subset))
   expect_equal(dim(subset), c(1, 6))
 
+  expect_error(subset <- subset[, 1 : 4], NA)
+  expect_true(is.pTs(subset))
+  expect_equal(dim(subset), c(1, 4))
+
   expect_error(subset <- pfield[, 1], NA)
   expect_true(is.pTs(subset))
   expect_equal(dim(subset), NULL)
@@ -79,6 +83,10 @@ test_that("pTs indexing works correctly for single-site pTs.", {
   expect_true(is.pTs(subset))
   expect_equal(dim(subset), c(1, 10))
 
+  expect_error(subset <- subset[, 1 : 5], NA)
+  expect_true(is.pTs(subset))
+  expect_equal(dim(subset), c(1, 5))
+
   expect_error(subset <- pts[, 1], NA)
   expect_true(is.pTs(subset))
   expect_equal(dim(subset), NULL)
@@ -130,6 +138,10 @@ test_that("pTs indexing works correctly for multi-site pTs.", {
   expect_error(subset <- pts[1, ], NA)
   expect_true(is.pTs(subset))
   expect_equal(dim(subset), c(1, 10))
+
+  expect_error(subset <- subset[, 1 : 5], NA)
+  expect_true(is.pTs(subset))
+  expect_equal(dim(subset), c(1, 5))
 
   expect_error(subset <- pts[, 1], NA)
   expect_true(is.pTs(subset))

--- a/tests/testthat/test-indexing.R
+++ b/tests/testthat/test-indexing.R
@@ -1,0 +1,62 @@
+
+context("test-indexing")
+
+test_that("pField indexing works correctly", {
+
+  # Create a pField
+  lat <- c(-75, -80)
+  lon <- c(0, 135, 215)
+  time <- 1 : 4
+  space <- c(1, 1, 1, 2, 2, 2)
+  spacetime <- c(space, 10 * space, 100 * space, 1000 * space)
+
+  pfield <- pField(data = spacetime, lat = lat, lon = lon, time = time)
+
+  # Test single indexing
+
+  expect_error(subset <- pfield[1, ], NA)
+  expect_true(is.pField(subset))
+
+  expect_error(subset <- pfield[, 1], NA)
+  expect_true(is.pTs(subset))
+
+  expect_warning(subset <- pfield[10])
+  expect_equal(c(subset), 10)
+
+  expect_error(subset <- pfield[1, 1], NA)
+  expect_true(is.pTs(subset))
+  expect_equal(unname(c(subset)), 1)
+
+  # Test 1D vector indexing
+
+  expect_warning(subset <- pfield[1 : 10])
+
+  expect_error(subset <- pfield[1 : 3, ], NA)
+  expect_true(is.pField(subset))
+
+  expect_error(subset <- pfield[, 1 : 3], NA)
+  expect_true(is.pField(subset))
+
+  expect_error(subset <- pfield[, 1 : 4], NA)
+  expect_true(is.pTs(subset))
+
+  # Test indexing by one vector and one integer
+
+  expect_error(subset <- pfield[1, 1 : 3], NA)
+  expect_true(is.pField(subset))
+
+  expect_error(subset <- pfield[1, 1 : 4], NA)
+  expect_true(is.pTs(subset))
+
+  expect_error(subset <- pfield[1 : 3, 1], NA)
+  expect_true(is.pTs(subset))
+
+  # Test 2D vector indexing
+
+  expect_error(subset <- pfield[1 : 3, 1 : 3], NA)
+  expect_true(is.pField(subset))
+
+  expect_error(subset <- pfield[1 : 3, 1 : 5], NA)
+  expect_true(is.pTs(subset))
+
+})


### PR DESCRIPTION
This PR introduces the following two updates:

* the subsetting of pField and pTs objects has been updated to fix an error which occurred when either subsetting a single timestep but leaving multiple columns, or when subsetting multiple columns on an object which already has only one time step, and when the subset result is a pTs object.
* test infrastructure has been set up and the updated indexing methods are tested (all tests ok).