### PR TITLE
Adapt functions for pField and pTs support

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pfields
 Title: An R Package to Analyse Gridded Field Data
-Version: 0.1.1.9000
+Version: 0.2.1.9000
 Author:
   Thomas Muench [aut, cre],
   Thomas Laepple [aut]

--- a/R/apply-fields.R
+++ b/R/apply-fields.R
@@ -1,8 +1,9 @@
 ##' Apply a function across space
 ##'
-##' Apply a function across the spatial dimension of a \code{"pField"} object by
-##' using \code{apply} on the rows of the object. The result of this gives a
-##' \code{"pTs"} vector object, i.e. a single time series.
+##' Apply a function across the spatial dimension of a \code{"pField"} or
+##' \code{"pTs"} object by using \code{apply} on the rows of the object. The
+##' result of this gives a \code{"pTs"} vector object, i.e. a single time
+##' series.
 ##'
 ##' Input columns which only contain NA values are stripped befor applying the
 ##' function. If only one non-NA column is present, this column is returned
@@ -17,6 +18,9 @@
 ##' @examples
 ##' x <- pField(data = array(rnorm(10 * 10 * 100), dim = c(10, 10, 100)),
 ##'             time = 1 : 100, lat = 1 : 10, lon = 1 : 10)
+##' ApplySpace(x, sd)
+##'
+##' x <- x[, 1 : 15]
 ##' ApplySpace(x, sd)
 ##' @aliases applyspace ApplySpace
 ##' @export applyspace ApplySpace

--- a/R/apply-fields.R
+++ b/R/apply-fields.R
@@ -175,6 +175,11 @@ applytime <- function(...) {
 ##' @export
 ApplyFields <- function(fld1, fld2, FUN, newtime = NULL, ...) {
 
+  # Validate input
+  if (!is.pField(fld1) | !is.pField(fld2)) {
+    stop("Input fields must be pField objects.")
+  }
+
   # Check dimensions of input objects
 
   if (sum(dim(fld1)) != sum(dim(fld2))) {
@@ -183,7 +188,7 @@ ApplyFields <- function(fld1, fld2, FUN, newtime = NULL, ...) {
 
   # Check fields for same time and Lat-Lon basis
 
-  if (max(abs(stats::time(fld1) - stats::time(fld2))) != 0) {
+  if (max(abs(c(stats::time(fld1)) - c(stats::time(fld2)))) != 0) {
     stop("Supplied fields have different observation times.")
   }
   if (max(abs(GetLat(fld1) - GetLat(fld2))) != 0) {

--- a/R/distance-fields.R
+++ b/R/distance-fields.R
@@ -1,11 +1,12 @@
-##' pField latitude and longitude fields
+##' Latitude and longitude fields
 ##'
 ##' Get latitude and longitude field vectors from the latitude and longitude
-##' attributes of a \code{"pField"} object. These fields follow the same spatial
-##' pattern as the input object (i.e., for the first latitude the indices run
-##' along all longitudes, then jump to the next latitude, and so further).
-##' @param data a \code{"pField"} object for which to return the lat/lon
-##' fields.
+##' attributes of a \code{"pField"} or \code{"pTs"} object. These fields follow
+##' the same spatial pattern as the input object (i.e., for the first latitude
+##' the indices run along all longitudes, then jump to the next latitude, and so
+##' further).
+##' @param data a \code{"pField"} or \code{"pTs"} object for which to return the
+##' lat/lon fields.
 ##' @param simplify if \code{FALSE} (the default), the fields are returned as a
 ##' two component list, otherwise as a 2 x n matrix, where the first row is the
 ##' latitude and the second row the longitude field.
@@ -18,17 +19,35 @@
 ##' latlons <- GetLatLonField(field)
 ##' latlons$lat2d
 ##' latlons$lon2d
+##'
+##' # subset incompletely to create a pTs object
+##' field <- field[, 1 : 4]
+##' latlons <- GetLatLonField(field)
+##' latlons$lat2d
+##' latlons$lon2d
 ##' @export
 GetLatLonField <- function(data, simplify = FALSE) {
 
   lat <- GetLat(data)
   lon <- GetLon(data)
 
-  nlat <- length(lat)
-  nlon <- length(lon)
+  if (is.pTs(data)) {
 
-  lon2d <- rep(lon, nlat)
-  lat2d <- rep(lat, each = nlon)
+    lon2d <- lon
+    lat2d <- lat
+
+  } else if (is.pField(data)) {
+
+    nlat <- length(lat)
+    nlon <- length(lon)
+
+    lon2d <- rep(lon, nlat)
+    lat2d <- rep(lat, each = nlon)
+
+  } else {
+
+    stop("Input is whether pField nor pTs object.")
+  }
 
   res <- list(lat2d = lat2d, lon2d = lon2d)
 

--- a/R/math-functions.R
+++ b/R/math-functions.R
@@ -34,6 +34,10 @@ cor.pTs <- function(point, field, debug = FALSE, ...) {
   start <- max(start(point)[1], start(field)[1])
   end <- min(end(point)[1], end(field)[1])
 
+  if (start > end) {
+    stop("'point' and 'field' have non-overlapping observation times.")
+  }
+
   if (debug) {
     message(paste("Common time period:", start, end))
   }

--- a/R/math-functions.R
+++ b/R/math-functions.R
@@ -26,66 +26,66 @@
 ##' @export
 cor.pTs <- function(point, field, debug = FALSE, ...) {
 
-    if (!is.null(dim(point))) {
-        if (ncol(point) > 1) stop("'point' is not a single point time series.")
-    }
-    
-    # Bring input data on the same time basis
-    start <- max(start(point)[1], start(field)[1])
-    end <- min(end(point)[1], end(field)[1])
-    
-    if (debug) {
-        message(paste("Common time period:", start, end))
-    }
+  if (!is.null(dim(point))) {
+    if (ncol(point) > 1) stop("'point' is not a single point time series.")
+  }
 
-    x <- stats::window(point, start, end)
-    y <- stats::window(field, start, end)
+  # Bring input data on the same time basis
+  start <- max(start(point)[1], start(field)[1])
+  end <- min(end(point)[1], end(field)[1])
 
-    if (is.pField(field)) {
+  if (debug) {
+    message(paste("Common time period:", start, end))
+  }
 
-        # Correlation with pField
-        class(y) <- "matrix"
+  x <- stats::window(point, start, end)
+  y <- stats::window(field, start, end)
 
-        res <- stats::cor(x, y, ...)
-        attr(res, "history") <- c(
-            sprintf("A (%s):", GetName(point)), GetHistory(point),
-            sprintf("B (%s):", GetName(field)), GetHistory(field))
-        hist <- paste0("cor.pTs(", GetName(point), ", ", GetName(field), ")")
+  if (is.pField(field)) {
 
-        res <- pField(res, time = max(stats::time(field)),
-                      lat = GetLat(field), lon = GetLon(field),
-                      name = "correlation", history = hist)
-        
-    } else if (is.pTs(field)) {
+    # Correlation with pField
+    class(y) <- "matrix"
 
-        # Correlation with pTs
-        class(y) <- "matrix"
+    res <- stats::cor(x, y, ...)
+    attr(res, "history") <- c(
+      sprintf("A (%s):", GetName(point)), GetHistory(point),
+      sprintf("B (%s):", GetName(field)), GetHistory(field))
+    hist <- paste0("cor.pTs(", GetName(point), ", ", GetName(field), ")")
 
-        res <- stats::cor(x, y, ...)
-        attr(res, "history") <- c(
-            sprintf("A (%s):", GetName(point)), GetHistory(point),
-            sprintf("B (%s):", GetName(field)), GetHistory(field))
-        hist <- paste0("cor.pTs(", GetName(point), ", ", GetName(field), ")")
+    res <- pField(res, time = max(stats::time(field)),
+                  lat = GetLat(field), lon = GetLon(field),
+                  name = "correlation", history = hist)
 
-        res <- pTs(res, time = max(stats::time(field)),
-                   lat = GetLat(field), lon = GetLon(field),
-                   name = "correlation", history = hist)
+  } else if (is.pTs(field)) {
 
-    } else {
+    # Correlation with pTs
+    class(y) <- "matrix"
 
-        # Correlation with other object
-        res <- stats::cor(x, y, ...)
+    res <- stats::cor(x, y, ...)
+    attr(res, "history") <- c(
+      sprintf("A (%s):", GetName(point)), GetHistory(point),
+      sprintf("B (%s):", GetName(field)), GetHistory(field))
+    hist <- paste0("cor.pTs(", GetName(point), ", ", GetName(field), ")")
 
-        attr(res, "history") <- c(
-            sprintf("A (%s):", GetName(point)), GetHistory(point),
-            sprintf("B (%s):", deparse(substitute(field))))
-        hist <- paste0("cor.pTs(", GetName(point), ", ",
-                       deparse(substitute(field)), ")")
+    res <- pTs(res, time = max(stats::time(field)),
+               lat = GetLat(field), lon = GetLon(field),
+               name = "correlation", history = hist)
 
-        res <- AddHistory(res, hist)
-    }
+  } else {
 
-    return(res)
+    # Correlation with other object
+    res <- stats::cor(x, y, ...)
+
+    attr(res, "history") <- c(
+      sprintf("A (%s):", GetName(point)), GetHistory(point),
+      sprintf("B (%s):", deparse(substitute(field))))
+    hist <- paste0("cor.pTs(", GetName(point), ", ",
+                   deparse(substitute(field)), ")")
+
+    res <- AddHistory(res, hist)
+  }
+
+  return(res)
 }
 
 ##' Decorrelation of field

--- a/R/math-functions.R
+++ b/R/math-functions.R
@@ -1,16 +1,17 @@
 ##' Correlation of point with field
 ##'
-##' Calculate the correlation between an object of class \code{"pTs"} and an
-##' object of class \code{"pField"}.
-##' @param point a \code{"pTs"} object.
-##' @param field a \code{"pField"} object.
+##' Calculate the correlation between a point time series of class \code{"pTs"}
+##' and a field of class \code{"pField"} or \code{"pTs"}, but also supports
+##' standard objects.
+##' @param point a \code{"pTs"} point object.
+##' @param field a \code{"pField"} or \code{"pTs"} field.
 ##' @param debug \code{point} and \code{field} are brought onto the same time
 ##' basis. If \code{debug = TRUE}, this new time basis is printed as a message.
 ##' @param ... further arguments passed on to the base R correlation function
 ##' \code{\link[stats]{cor}}, such as the \code{use} argument.
 ##' @return the correlation(s) between \code{point} and \code{field}. The class
 ##' of the result depends on the class of \code{field}, so a \code{"pField"}
-##' object usually.
+##' or \code{"pTs"} object usually.
 ##' @source Function based on "mat.pField.R" in paleolibary/src/.
 ##' @author Thomas Laepple, modified by Thomas Münch
 ##' @examples
@@ -19,8 +20,15 @@
 ##'                 lat = 1 : 10, lon = 1 : 10)
 ##'
 ##' correlation <- cor.pTs(point, field)
+##'
+##' pts.field <- field[, 1 : 25]
+##' correlation <- cor.pTs(point, pts.field)
 ##' @export
 cor.pTs <- function(point, field, debug = FALSE, ...) {
+
+    if (!is.null(dim(point))) {
+        if (ncol(point) > 1) stop("'point' is not a single point time series.")
+    }
     
     # Bring input data on the same time basis
     start <- max(start(point)[1], start(field)[1])
@@ -48,6 +56,21 @@ cor.pTs <- function(point, field, debug = FALSE, ...) {
                       lat = GetLat(field), lon = GetLon(field),
                       name = "correlation", history = hist)
         
+    } else if (is.pTs(field)) {
+
+        # Correlation with pTs
+        class(y) <- "matrix"
+
+        res <- stats::cor(x, y, ...)
+        attr(res, "history") <- c(
+            sprintf("A (%s):", GetName(point)), GetHistory(point),
+            sprintf("B (%s):", GetName(field)), GetHistory(field))
+        hist <- paste0("cor.pTs(", GetName(point), ", ", GetName(field), ")")
+
+        res <- pTs(res, time = max(stats::time(field)),
+                   lat = GetLat(field), lon = GetLon(field),
+                   name = "correlation", history = hist)
+
     } else {
 
         # Correlation with other object

--- a/R/small-methods.R
+++ b/R/small-methods.R
@@ -303,10 +303,10 @@ is.pTs <- function(object) {
 
 ##' Convert field to data frame
 ##'
-##' Convert a static \code{"pField"} object, i.e. including only one time step,
-##' to a data frame with data, latitude and longitude columns, with the
-##' possibility to cut out a specified latitude-longitude region.
-##' @param data a \code{"pField"} object with one timestep.
+##' Convert a static \code{"pField"} or \code{"pTs"} object, i.e. including only
+##' one time step, to a data frame with data, latitude and longitude columns,
+##' with the possibility to cut out a specified latitude-longitude region.
+##' @param data a \code{"pField"} or \code{"pTs"} object with one timestep.
 ##' @param lat.min set the minimum latitude for the output; per default the
 ##' minimum in \code{data} is used.
 ##' @param lat.max set the maximum latitude for the output; per default the
@@ -340,6 +340,14 @@ is.pTs <- function(object) {
 ##' # Cut out some region
 ##' x.df <- pField2df(x.avg, lat.min = -75, lon.min = 0, lon.max = 200)
 ##' x.df
+##'
+##' # Subset incompletely to create a pTs object
+##' x.pts <- x[, 1 : 4]
+##' x.avg <- ApplyTime(x.pts, mean)
+##'
+##' # Convert to data frame
+##' x.df <- pField2df(x.avg)
+##' x.df # the same as x.df[1 : 4,] from above
 ##' @export
 pField2df <- function(data,
                       lat.min = NULL, lat.max = NULL,

--- a/man/ApplySpace.Rd
+++ b/man/ApplySpace.Rd
@@ -22,9 +22,10 @@ a single \code{"pTs"} time series with the results of the function
   applied.
 }
 \description{
-Apply a function across the spatial dimension of a \code{"pField"} object by
-using \code{apply} on the rows of the object. The result of this gives a
-\code{"pTs"} vector object, i.e. a single time series.
+Apply a function across the spatial dimension of a \code{"pField"} or
+\code{"pTs"} object by using \code{apply} on the rows of the object. The
+result of this gives a \code{"pTs"} vector object, i.e. a single time
+series.
 }
 \details{
 Input columns which only contain NA values are stripped befor applying the
@@ -34,6 +35,9 @@ unchanged with a warning.
 \examples{
 x <- pField(data = array(rnorm(10 * 10 * 100), dim = c(10, 10, 100)),
             time = 1 : 100, lat = 1 : 10, lon = 1 : 10)
+ApplySpace(x, sd)
+
+x <- x[, 1 : 15]
 ApplySpace(x, sd)
 }
 \author{

--- a/man/ApplySpace.Rd
+++ b/man/ApplySpace.Rd
@@ -11,19 +11,25 @@ Function copied from "basis.R" in paleolibary/src/.
 ApplySpace(data, FUN, ...)
 }
 \arguments{
-\item{data}{a \code{"pField"} object.}
+\item{data}{a \code{"pField"} or \code{"pTs"} object.}
 
 \item{FUN}{the function to be applied.}
 
 \item{...}{further arguments passed on to \code{FUN}.}
 }
 \value{
-a \code{"pTs"} object with the results of the function applied.
+a single \code{"pTs"} time series with the results of the function
+  applied.
 }
 \description{
 Apply a function across the spatial dimension of a \code{"pField"} object by
 using \code{apply} on the rows of the object. The result of this gives a
-\code{"pTs"} object.
+\code{"pTs"} vector object, i.e. a single time series.
+}
+\details{
+Input columns which only contain NA values are stripped befor applying the
+function. If only one non-NA column is present, this column is returned
+unchanged with a warning.
 }
 \examples{
 x <- pField(data = array(rnorm(10 * 10 * 100), dim = c(10, 10, 100)),

--- a/man/ApplyTime.Rd
+++ b/man/ApplyTime.Rd
@@ -11,28 +11,34 @@ Function copied from "basis.R" in paleolibary/src/.
 ApplyTime(data, FUN, newtime = NULL, ...)
 }
 \arguments{
-\item{data}{a \code{"pField"} object.}
+\item{data}{a \code{"pField"} or \code{"pTs"} object.}
 
 \item{FUN}{the function to be applied.}
 
-\item{newtime}{Specify the observation time point corresponding to the
-resulting \code{"pField"} object. For \code{NULL} (the default), the average
-of the time points in \code{data} is used.}
+\item{newtime}{Specify the observation time point of the result. For
+\code{NULL} (the default), the average of the time points in \code{data} is
+used.}
 
 \item{...}{further arguments passed on to \code{FUN}.}
 }
 \value{
-a \code{"pField"} object with the results of the function applied.
+a \code{"pField"} or \code{"pTs"} object with the results of the
+function applied.
 }
 \description{
-Apply a function across the temporal dimension of a \code{"pField"} object by
-using \code{apply} on the columns of the object. The result of this gives
-a \code{"pField"} object with only one time step.
+Apply a function across the temporal dimension of a \code{"pField"} or
+\code{"pTs"} object by using \code{apply} on the columns of the object. The
+result of this gives a \code{"pField"} or \code{"pTs"} object with only one
+time step.
 }
 \examples{
 x <- pField(data = array(rnorm(10 * 10 * 100), dim = c(10, 10, 100)),
             time = 1 : 100, lat = 1 : 10, lon = 1 : 10)
-ApplyTime(x, mean)
+y <- ApplyTime(x, mean)
+
+# subset incompletely to create a pTs object
+x.pts <- x[, 1 : 15]
+y.pts <- ApplyTime(x.pts, mean) # is the same as y[, 1 : 15]
 }
 \author{
 Thomas Laepple

--- a/man/GetLatLonField.Rd
+++ b/man/GetLatLonField.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/distance-fields.R
 \name{GetLatLonField}
 \alias{GetLatLonField}
-\title{pField latitude and longitude fields}
+\title{Latitude and longitude fields}
 \source{
 Function copied from "basis.R" in paleolibary/src/.
 }
@@ -10,8 +10,8 @@ Function copied from "basis.R" in paleolibary/src/.
 GetLatLonField(data, simplify = FALSE)
 }
 \arguments{
-\item{data}{a \code{"pField"} object for which to return the lat/lon
-fields.}
+\item{data}{a \code{"pField"} or \code{"pTs"} object for which to return the
+lat/lon fields.}
 
 \item{simplify}{if \code{FALSE} (the default), the fields are returned as a
 two component list, otherwise as a 2 x n matrix, where the first row is the
@@ -22,13 +22,20 @@ a two component list or 2 x n matrix.
 }
 \description{
 Get latitude and longitude field vectors from the latitude and longitude
-attributes of a \code{"pField"} object. These fields follow the same spatial
-pattern as the input object (i.e., for the first latitude the indices run
-along all longitudes, then jump to the next latitude, and so further).
+attributes of a \code{"pField"} or \code{"pTs"} object. These fields follow
+the same spatial pattern as the input object (i.e., for the first latitude
+the indices run along all longitudes, then jump to the next latitude, and so
+further).
 }
 \examples{
 field <- pField(lat = seq(0, 90, 10), lon = c(-10, 0, 10))
 
+latlons <- GetLatLonField(field)
+latlons$lat2d
+latlons$lon2d
+
+# subset incompletely to create a pTs object
+field <- field[, 1 : 4]
 latlons <- GetLatLonField(field)
 latlons$lat2d
 latlons$lon2d

--- a/man/cor.pTs.Rd
+++ b/man/cor.pTs.Rd
@@ -10,9 +10,9 @@ Function based on "mat.pField.R" in paleolibary/src/.
 cor.pTs(point, field, debug = FALSE, ...)
 }
 \arguments{
-\item{point}{a \code{"pTs"} object.}
+\item{point}{a \code{"pTs"} point object.}
 
-\item{field}{a \code{"pField"} object.}
+\item{field}{a \code{"pField"} or \code{"pTs"} field.}
 
 \item{debug}{\code{point} and \code{field} are brought onto the same time
 basis. If \code{debug = TRUE}, this new time basis is printed as a message.}
@@ -23,11 +23,12 @@ basis. If \code{debug = TRUE}, this new time basis is printed as a message.}
 \value{
 the correlation(s) between \code{point} and \code{field}. The class
 of the result depends on the class of \code{field}, so a \code{"pField"}
-object usually.
+or \code{"pTs"} object usually.
 }
 \description{
-Calculate the correlation between an object of class \code{"pTs"} and an
-object of class \code{"pField"}.
+Calculate the correlation between a point time series of class \code{"pTs"}
+and a field of class \code{"pField"} or \code{"pTs"}, but also supports
+standard objects.
 }
 \examples{
 point <- rnorm(100)
@@ -35,6 +36,9 @@ field <- pField(rnorm(100 * 10 * 10), time = 1 : 100,
                 lat = 1 : 10, lon = 1 : 10)
 
 correlation <- cor.pTs(point, field)
+
+pts.field <- field[, 1 : 25]
+correlation <- cor.pTs(point, pts.field)
 }
 \author{
 Thomas Laepple, modified by Thomas Münch

--- a/man/pField2df.Rd
+++ b/man/pField2df.Rd
@@ -8,7 +8,7 @@ pField2df(data, lat.min = NULL, lat.max = NULL, lon.min = NULL,
   lon.max = NULL)
 }
 \arguments{
-\item{data}{a \code{"pField"} object with one timestep.}
+\item{data}{a \code{"pField"} or \code{"pTs"} object with one timestep.}
 
 \item{lat.min}{set the minimum latitude for the output; per default the
 minimum in \code{data} is used.}
@@ -28,9 +28,9 @@ A data frame with the three columns \code{lat} (latitudes),
   coordinate positions).
 }
 \description{
-Convert a static \code{"pField"} object, i.e. including only one time step,
-to a data frame with data, latitude and longitude columns, with the
-possibility to cut out a specified latitude-longitude region.
+Convert a static \code{"pField"} or \code{"pTs"} object, i.e. including only
+one time step, to a data frame with data, latitude and longitude columns,
+with the possibility to cut out a specified latitude-longitude region.
 }
 \examples{
 # Create a pfield object covering two latitudes, three longitudes and
@@ -53,6 +53,14 @@ x.df
 # Cut out some region
 x.df <- pField2df(x.avg, lat.min = -75, lon.min = 0, lon.max = 200)
 x.df
+
+# Subset incompletely to create a pTs object
+x.pts <- x[, 1 : 4]
+x.avg <- ApplyTime(x.pts, mean)
+
+# Convert to data frame
+x.df <- pField2df(x.avg)
+x.df # the same as x.df[1 : 4,] from above
 }
 \author{
 Thomas Münch

--- a/tests/testthat/test-apply-functions.R
+++ b/tests/testthat/test-apply-functions.R
@@ -1,0 +1,129 @@
+context("test-apply-functions")
+
+test_that("ApplySpace works.", {
+
+  # Test that errors are caught
+
+  # input is not pfield nor pts
+  input <- rnorm(100)
+  expect_error(output <- ApplySpace(input, sd))
+
+  # input is no matrix
+  input <- pTs(input, time = 1 : length(input))
+  expect_error(output <- ApplySpace(input, sd))
+
+  # input has only one column
+  input <- rnorm(100)
+  field <- pField(input, time = 1 : length(input), lat = 1, lon = 1)
+  expect_error(output <- ApplySpace(field, sd))
+
+  # input is only NA
+  input <- rep(NA, 200)
+  field <- pField(input, time = 1 : (length(input) / 2), lat = 1, lon = 1 : 2)
+  expect_error(output <- ApplySpace(field, sd))
+
+  # input has only one non-NA column
+  input <- matrix(c(1 : 100, rep(NA, 100)), ncol = 100, byrow = TRUE)
+  field <- pField(input, time = 1 : (length(input) / 2), lat = 1, lon = 1 : 2)
+  expect_warning(output <- ApplySpace(field, sd))
+  expect_equal(as.numeric(output), input[1, ])
+
+  # Test output
+
+  # using deprecated function name
+  field <- pField(1, time = 1 : 100, lat = 1, lon = 1 : 2)
+  expect_warning(applyspace(field, sd))
+
+  # input pField
+  field <- pField(1, time = 1 : 100, lat = 1, lon = 1 : 2)
+  output <- ApplySpace(field, sd)
+  expect_true(is.pTs(output))
+  expect_equal(as.numeric(output), rep(0, 100))
+
+  # input pTs
+  input <- matrix(rep(0, 200), nrow = 100)
+  field <- pTs(input, time = 1 : 100)
+  output <- ApplySpace(field, sd)
+  expect_true(is.pTs(output))
+  expect_equal(as.numeric(output), rep(0, 100))
+  
+})
+
+test_that("ApplyTime works.", {
+
+  # Test that errors are caught
+
+  # input is not pfield nor pts
+  input <- rnorm(100)
+  expect_error(output <- ApplyTime(input, sd))
+
+  # input is no matrix
+  input <- pTs(input, time = 1 : length(input))
+  expect_error(output <- ApplyTime(input, sd))
+
+  # input has only one time step
+  input <- rnorm(100)
+  field <- pField(input, time = 1, lat = 1, lon = 1 : 100)
+  expect_error(output <- ApplyTime(field, sd))
+
+  # Test output
+
+  # using deprecated function name
+  field <- pField(1, time = 1 : 100, lat = 1, lon = 1 : 5)
+  expect_warning(applytime(field, sd))
+
+  # input pField
+  field <- pField(1, time = 1 : 100, lat = 1, lon = 1 : 5)
+  output <- ApplyTime(field, sd)
+  expect_true(is.pField(output))
+  expect_equal(as.numeric(output), rep(0, 5))
+
+  # input pTs
+  input <- matrix(rep(0, 100), nrow = 20)
+  field <- pTs(input, time = 1 : 20)
+  output <- ApplyTime(field, sd)
+  expect_true(is.pTs(output))
+  expect_equal(as.numeric(output), rep(0, 5))
+
+})
+
+test_that("ApplyFields works.", {
+
+  # Test that errors are caught
+
+  # input is not pField
+  expect_error(ApplyFields(1 : 10, 1 : 10, FUN = cor))
+  expect_error(ApplyFields(1 : 10,
+                           pField(1 : 10, time = 1 : 10, lat = 1, lon = 1),
+                           FUN = cor))
+
+  # input has different dimensions
+  fld1 <- pField(1 : 10, time = 1 : 10, lat = 1, lon = 1)
+  fld2 <- pField(1 : 10, time = 1 : 5, lat = 1, lon = 1 : 2)
+  expect_error(ApplyFields(fld1, fld2, FUN = cor))
+
+  # input has different observation times
+  fld1 <- pField(1 : 10, time = 1 : 10, lat = 1, lon = 1)
+  fld2 <- pField(1 : 10, time = 11 : 20, lat = 1, lon = 1)
+  expect_error(ApplyFields(fld1, fld2, FUN = cor))
+
+  # input has different longitudes
+  fld1 <- pField(1 : 10, time = 1 : 10, lat = 1, lon = 1)
+  fld2 <- pField(1 : 10, time = 1 : 10, lat = 1, lon = 2)
+  expect_error(ApplyFields(fld1, fld2, FUN = cor))
+
+  # input has different latitudes
+  fld1 <- pField(1 : 10, time = 1 : 10, lat = 1, lon = 1)
+  fld2 <- pField(1 : 10, time = 1 : 10, lat = 2, lon = 2)
+  expect_error(ApplyFields(fld1, fld2, FUN = cor))
+
+  # Test output
+
+  fld1 <- pField(1 : 10, time = 1 : 5, lat = 1, lon = 1 : 2)
+  fld2 <- pField(1 : 10, time = 1 : 5, lat = 1, lon = 1 : 2)
+  output <- ApplyFields(fld1, fld2, FUN = cor)
+  expect_true(is.pField(output))
+  expect_equal(dim(output), c(1, 2))
+  expect_equal(c(output), rep(1, 2))
+
+})

--- a/tests/testthat/test-math-functions.R
+++ b/tests/testthat/test-math-functions.R
@@ -1,0 +1,48 @@
+context("test-math-functions")
+
+test_that("cor.pTs works.", {
+
+  # Test that errors are caught
+
+  # input is not a single point
+  point <- matrix(rnorm(100), ncol = 2)
+  field <- point
+  expect_error(cor.pTs(point, field))
+
+  # input has no temporal overlap
+  point <- pTs(rnorm(100), time = 1 : 100)
+  field <- pField(1, time = 101 : 200, lat = 1, lon = 1 : 2)
+  expect_error(cor.pTs(point, field))
+
+  # Test output
+
+  # input pField as field
+  point <- pTs(1 : 5, time = 1 : 5)
+  field <- pField(1 : 10, time = 1 : 5, lat = 1, lon = 1 : 2)
+  output <- cor.pTs(point, field)
+  expect_true(is.pField(output))
+  expect_equal(dim(output), c(1, 2))
+  expect_equal(c(output), rep(1, 2))
+
+  # input pTs as field
+  point <- pTs(1 : 5, time = 1 : 5)
+  field <- pTs(matrix(1 : 10, nrow = 5), time = 1 : 5, lat = 1 : 2, lon = 1 : 2)
+  output <- cor.pTs(point, field)
+  expect_true(is.pTs(output))
+  expect_equal(dim(output), c(1, 2))
+  expect_equal(c(output), rep(1, 2))
+
+  # input standard matrix as field
+  point <- pTs(1 : 5, time = 1 : 5)
+  field <- matrix(1 : 10, nrow = 5)
+  output <- cor.pTs(point, field)
+  expect_equal(dim(output), c(1, 2))
+  expect_equal(c(output), rep(1, 2))
+
+  # shorter common temporal overlap
+  point <- pTs(1 : 5, time = 1 : 5)
+  field <- pField(1 : 6, time = 2 : 4, lat = 1, lon = 1 : 2)
+  expect_message(output <- cor.pTs(point, field, debug = TRUE))
+  expect_equal(c(stats::time(output)), 4)
+  
+})


### PR DESCRIPTION
This PR introduces two updates:
* the following functions now handle consistently both pFields and pTs objects:
  * `GetLatLonField()`,
  * `ApplyTime()`,
  * `ApplySpace()`,
  * `cor.pTs()`,
  * `pField2df()`.
* new tests have been added to check the functionality of
  * `ApplyTime()`,
  * `ApplySpace()`,
  * `ApplyFields()`,
  * `cor.pTs()`.