### PR TITLE
Improve setting of the output time step in ApplyTime()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pfields
 Title: An R Package to Analyse Gridded Field Data
-Version: 0.3.2
+Version: 0.3.3
 Author:Thomas Muench [aut, cre], Thomas Laepple [aut]
 Maintainer: Thomas Muench <thomas.muench@awi.de>
 Description: This R package provides functions to create and

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# pfields 0.3.3
+
+* `ApplyTime()`: improved setting and error checking of output time step.
+
 # pfields 0.3.2
 
 * `ApplyTime()` now correctly handles applied functions which yield more than

--- a/man/ApplyTime.Rd
+++ b/man/ApplyTime.Rd
@@ -17,8 +17,9 @@ ApplyTime(data, FUN, newtime = NULL, ...)
 
 \item{newtime}{the observation time point(s) of the result. For \code{NULL}
 (the default), the average of the time points in \code{data} is used,
-assuming the applied function yields an aggregated result. If the result of
-\code{FUN} yields more than one time step, you need to provide the
+if the applied function yields an aggregated result (i.e. one time step),
+and the original time points in \code{data} if the result has as many time
+steps as the input data. For other cases, you need to provide the
 respective new time axis here.}
 
 \item{...}{further arguments passed on to \code{FUN}.}
@@ -30,7 +31,7 @@ function applied.
 \description{
 Apply a function across the temporal dimension of a \code{"pField"} or
 \code{"pTs"} object by using \code{apply} on the columns of the
-object. Depending in the output of the applied function, this gives a
+object. Depending on the output of the applied function, this gives a
 \code{"pField"} or \code{"pTs"} object with only one, or with several time
 steps.
 }
@@ -42,6 +43,9 @@ y <- ApplyTime(x, mean)
 # subset incompletely to create a pTs object
 x.pts <- x[, 1 : 15]
 y.pts <- ApplyTime(x.pts, mean) # is the same as y[, 1 : 15]
+
+# you need to supply a new time axis e.g. for use cases such as
+y <- ApplyTime(x, range, newtime = c(1, 2))
 }
 \author{
 Thomas Laepple

--- a/tests/testthat/test-apply-functions.R
+++ b/tests/testthat/test-apply-functions.R
@@ -66,9 +66,10 @@ test_that("ApplyTime works.", {
   field <- pField(input, time = 1, lat = 1, lon = 1 : 100)
   expect_error(output <- ApplyTime(field, sd))
 
-  # result has >1 time step but no new time axis supplied
+  # result has >1 time step but no new, or wrong, time axis supplied
   field <- pField(1, time = 1 : 100, lat = 1, lon = 1 : 5)
   expect_error(output <- ApplyTime(field, range))
+  expect_error(output <- ApplyTime(field, range, newtime = c(1, 2, 3)))
   expect_error(output <- ApplyTime(field, range, newtime = c(1, 2)), NA)
 
   # Test output
@@ -94,15 +95,19 @@ test_that("ApplyTime works.", {
   expect_true(is.pTs(output))
   expect_equal(as.numeric(output), rep(0, 5))
 
-  # result has more than one time step
+  # result has as many time steps as input data
   field <- pField(1 : 50, time = 1 : 10, lat = 1, lon = 1 : 5)
-  output <- ApplyTime(field, FUN = function(x) {x}, newtime = time(field))
+  output <- expect_error(
+    ApplyTime(field, FUN = function(x) {x}, newtime = time(field)), NA)
+  attr(output, "history") <- NULL
+  expect_equal(field, output)
+  output <- expect_error(ApplyTime(field, FUN = function(x) {x}), NA)
   attr(output, "history") <- NULL
   expect_equal(field, output)
 
   input <- matrix(1 : 20, nrow = 10)
   field <- pTs(input, time = 1 : 10)
-  output <- ApplyTime(field, FUN = function(x) {x}, newtime = time(field))
+  output <- ApplyTime(field, FUN = function(x) {x})
   attr(output, "history") <- NULL
   expect_equal(field, output)
 


### PR DESCRIPTION
This PR directly builds on and improves #8, introducing the following updates to `ApplyTime()` which further improve the setting and error checking of the output time axis:

* automatic setting of the output time step now works as follows: if no new time axis is supplied, the output time axis is set to the mean time of the input times if the apply operation aggregates the input data (i.e. yielding only one time step), or it is set to the input time axis if the apply operation yields as many time steps as the input data (e.g. when filtering the field). For a different number of time steps of the apply operation and no specified new time axis, an error is issued;
* if a new time axis is supplied but does not match the row numbers (i.e. temporal dimension) of the result from the apply operation, an error is issued;
* function documentation, examples, and tests have been updated accordingly.